### PR TITLE
Add Nix dependencies

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -4,3 +4,5 @@ packages:
 - '.'
 extra-deps:
 resolver: lts-8.23
+nix:
+  packages: [gcc, ncurses]


### PR DESCRIPTION
This allows to build in one command if you use nix.

Note that `gcc` is needed due to a bug: https://github.com/judah/terminfo/commit/02ebf00cb2ab59d7924909306b7a791c7959f703